### PR TITLE
Fix: Park timer not resetting

### DIFF
--- a/real-brake-lights/client.lua
+++ b/real-brake-lights/client.lua
@@ -64,15 +64,11 @@ local function parkTimer()
 
   CreateThread(function()
     while true do
+      if (GetEntitySpeed(vehicle) * 2.236936)  > 0 then return end
       if GetGameTimer() > expiration then
-        local speed = GetEntitySpeed(vehicle) * 2.236936 -- get speed in MPH
-        if speed < 1 then
-          -- print("Setting park state to true")
-          TriggerServerEvent("rbl:setParked", VehToNet(vehicle), true)
-          return
-        else
-          return
-        end
+        -- print("Setting park state to true")
+        TriggerServerEvent("rbl:setParked", VehToNet(vehicle), true)
+        return
       end
       Wait(500)
     end


### PR DESCRIPTION
Park timer was not resetting because it checked for whether time was up before checking speed of vehicle.
If vehicle stared driving again then stopped before timer was up, timer would complete.

Fixed by moving speed check in front of time check so timer cancels any time the vehicle is moving.